### PR TITLE
Updates to the test applied while testing disabling strategy before merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7356,7 +7356,7 @@ dependencies = [
 [[package]]
 name = "zombienet-configuration"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk?rev=92c2338#92c233873daead09e1d8729be40d08d061cb20de"
+source = "git+https://github.com/paritytech/zombienet-sdk?rev=a22fb5d#a22fb5d7a2a4ff183ad3ff2f3b7c86bc225b3e1d"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7372,7 +7372,7 @@ dependencies = [
 [[package]]
 name = "zombienet-orchestrator"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk?rev=92c2338#92c233873daead09e1d8729be40d08d061cb20de"
+source = "git+https://github.com/paritytech/zombienet-sdk?rev=a22fb5d#a22fb5d7a2a4ff183ad3ff2f3b7c86bc225b3e1d"
 dependencies = [
  "anyhow",
  "futures",
@@ -7400,7 +7400,7 @@ dependencies = [
 [[package]]
 name = "zombienet-prom-metrics-parser"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk?rev=92c2338#92c233873daead09e1d8729be40d08d061cb20de"
+source = "git+https://github.com/paritytech/zombienet-sdk?rev=a22fb5d#a22fb5d7a2a4ff183ad3ff2f3b7c86bc225b3e1d"
 dependencies = [
  "pest",
  "pest_derive",
@@ -7410,10 +7410,11 @@ dependencies = [
 [[package]]
 name = "zombienet-provider"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk?rev=92c2338#92c233873daead09e1d8729be40d08d061cb20de"
+source = "git+https://github.com/paritytech/zombienet-sdk?rev=a22fb5d#a22fb5d7a2a4ff183ad3ff2f3b7c86bc225b3e1d"
 dependencies = [
  "anyhow",
  "async-trait",
+ "flate2",
  "futures",
  "hex",
  "k8s-openapi",
@@ -7430,6 +7431,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
  "uuid",
  "zombienet-configuration",
  "zombienet-support",
@@ -7438,10 +7440,11 @@ dependencies = [
 [[package]]
 name = "zombienet-sdk"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk?rev=92c2338#92c233873daead09e1d8729be40d08d061cb20de"
+source = "git+https://github.com/paritytech/zombienet-sdk?rev=a22fb5d#a22fb5d7a2a4ff183ad3ff2f3b7c86bc225b3e1d"
 dependencies = [
  "async-trait",
  "futures",
+ "lazy_static",
  "subxt",
  "tokio",
  "zombienet-configuration",
@@ -7453,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "zombienet-support"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk?rev=92c2338#92c233873daead09e1d8729be40d08d061cb20de"
+source = "git+https://github.com/paritytech/zombienet-sdk?rev=a22fb5d#a22fb5d7a2a4ff183ad3ff2f3b7c86bc225b3e1d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ subxt = { version = "0.33.0", default-features = false, features = ["native"] }
 subxt-signer = { version = "0.33.0" }
 tokio = "1.35.0"
 tracing-subscriber = "0.3.18"
-zombienet-sdk = { git = "https://github.com/paritytech/zombienet-sdk", rev = "92c2338" }
+zombienet-sdk = { git = "https://github.com/paritytech/zombienet-sdk", rev = "a22fb5d" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,11 @@ pub fn runtime_config() -> serde_json::Value {
     json!({
         "configuration": {
             "config": {
-                "max_validators_per_core": 1,
                 "needed_approvals": 1,
-                "group_rotation_frequency": 10
+                "group_rotation_frequency": 10,
+                "scheduler_params": {
+                    "max_validators_per_core": 1,
+                }
             }
         }
     })
@@ -41,7 +43,6 @@ pub async fn spawn_network_malus_backer() -> Result<Network<LocalFileSystem>, Er
                 .with_default_command("polkadot")
                 .with_default_args(vec![
                     "--no-hardware-benchmarks".into(),
-                    "--insecure-validator-i-know-what-i-do".into(),
                     "-lparachain=debug".into(),
                 ])
                 .with_node(|node| node.with_name("honest-0"))
@@ -53,7 +54,6 @@ pub async fn spawn_network_malus_backer() -> Result<Network<LocalFileSystem>, Er
                         .with_subcommand("suggest-garbage-candidate")
                         .with_args(vec![
                             "--no-hardware-benchmarks".into(),
-                            "--insecure-validator-i-know-what-i-do".into(),
                             "-lMALUS=trace".into(),
                         ])
                 })
@@ -83,7 +83,6 @@ pub async fn spawn_network_dispute_valid() -> Result<Network<LocalFileSystem>, E
                 .with_default_command("polkadot")
                 .with_default_args(vec![
                     "--no-hardware-benchmarks".into(),
-                    "--insecure-validator-i-know-what-i-do".into(),
                     "-lparachain=debug,parachain::dispute-coordinator=trace".into(),
                 ])
                 .with_node(|node| node.with_name("honest-0"))
@@ -101,7 +100,6 @@ pub async fn spawn_network_dispute_valid() -> Result<Network<LocalFileSystem>, E
                         .with_subcommand("dispute-ancestor")
                         .with_args(vec![
                             "--no-hardware-benchmarks".into(),
-                            "--insecure-validator-i-know-what-i-do".into(),
                             "-lMALUS=trace".into(),
                         ])
                 })
@@ -131,7 +129,6 @@ pub async fn spawn_honest_network() -> Result<Network<LocalFileSystem>, Error> {
                 .with_default_command("polkadot")
                 .with_default_args(vec![
                     "--no-hardware-benchmarks".into(),
-                    "--insecure-validator-i-know-what-i-do".into(),
                     "-lparachain=debug,parachain::dispute-coordinator=trace".into(),
                 ])
                 .with_node(|node| node.with_name("honest-0"))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,6 +15,7 @@ async fn test_backing_disabling() -> Result<(), Error> {
     let network = spawn_network_malus_backer().await?;
 
     println!("🚀🚀🚀 network deployed");
+    sleep(Duration::from_secs(30)).await;
 
     let honest = network.get_node("honest-0")?;
     let role = honest.reports("node_roles").await?;
@@ -69,6 +70,7 @@ async fn test_disputes_offchain_disabling() -> Result<(), Error> {
     let network = spawn_network_dispute_valid().await?;
 
     println!("🚀🚀🚀 network deployed");
+    sleep(Duration::from_secs(30)).await;
 
     let honest = network.get_node("honest-0")?;
     let role = honest.reports("node_roles").await?;
@@ -89,7 +91,7 @@ async fn test_disputes_offchain_disabling() -> Result<(), Error> {
     let total_disputes = honest.reports(DISPUTES_CONCLUDED_VALID).await? as u64;
 
     // wait a bit
-    sleep(Duration::from_secs(120)).await;
+    sleep(Duration::from_secs(60)).await;
 
     let new_total_disputes = honest.reports(DISPUTES_CONCLUDED_VALID).await? as u64;
 
@@ -111,6 +113,7 @@ async fn test_runtime_upgrade() -> Result<(), Error> {
     let network = spawn_honest_network().await?;
 
     println!("🚀🚀🚀 network deployed");
+    sleep(Duration::from_secs(60)).await;
 
     let honest = network.get_node("honest-0")?;
     let role = honest.reports("node_roles").await?;
@@ -126,6 +129,7 @@ async fn test_runtime_upgrade() -> Result<(), Error> {
     // assert_eq!(honest.reports("substrate_build_info{name=\"honest-0\",version=\"1.6.0-481165d9229\",chain=\"westend_local_testnet\"}").await?, 1_f64);
 
     perform_nodes_upgrade(&network).await?;
+    sleep(Duration::from_secs(60)).await;
 
     let client = get_client(&network, "honest-0").await?;
     // ensure new binary is running - see the comment for 'ensure old binary is running'
@@ -171,6 +175,7 @@ async fn test_runtime_upgrade_with_old_client() -> Result<(), Error> {
     let network = spawn_honest_network().await?;
 
     println!("🚀🚀🚀 network deployed");
+    sleep(Duration::from_secs(60)).await;
 
     let honest = network.get_node("honest-0")?;
     let role = honest.reports("node_roles").await?;


### PR DESCRIPTION
I made some adjustments to the test in order to have them passing before we merge https://github.com/paritytech/polkadot-sdk/pull/2226 :
* Update to the latest zombienet-sdk
* Remove `--insecure-validator-i-know-what-i-do` command line argument from validators execution command - looks like latest zombienet-sdk sets it automatically.
* Adjust test timings so that they pass
  *  For some reason initial binary startup takes more time so I've added a `sleep` before querying metrics. This will be fixed in the future by providing `wait_for_metric` function in zombienet-sdk. 
  * `test_disputes_offchain_disabling` was failing because a new session has been starting while we were waiting to see no new disputes are raised. Decreasing the wait time fixed this but it is hacky. We need to provide something smarter in the future.
  
We are about to sunset this repo in favour of https://github.com/paritytech/polkadot-sdk/pull/3442 but until it's merged let's have the tests up to date.